### PR TITLE
build: remove redundant and incomplete exports field

### DIFF
--- a/babel.config.jest.cjs
+++ b/babel.config.jest.cjs
@@ -4,10 +4,14 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 module.exports = {
-	env: {
-		test: {
-			plugins: ["@babel/plugin-transform-modules-commonjs"]
-		}
-	},
-	presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-typescript']
+    presets: [
+		[
+			'@babel/preset-env',
+			{
+				modules: 'commonjs'
+			}
+		],
+		'@babel/preset-react',
+		'@babel/preset-typescript'
+	]
 };

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -94,7 +94,7 @@ const config: Config = {
 	// A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
 	moduleNameMapper: {
 		'\\.(css|less)$': 'identity-obj-proxy',
-		"^(\\.\\.?\\/.+)\\.js$": "$1",
+		'^(\\.\\.?\\/.+)\\.js$': '$1'
 	},
 	// An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
 	// modulePathIgnorePatterns: [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
 			},
 			"devDependencies": {
 				"@babel/core": "^7.24.7",
-				"@babel/plugin-transform-modules-commonjs": "^7.24.7",
 				"@babel/preset-env": "^7.24.7",
 				"@babel/preset-react": "^7.24.7",
 				"@babel/preset-typescript": "^7.24.7",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
 	"types": "./lib/index.d.ts",
 	"type": "module",
 	"exports": {
-		"import": "./lib/index.js"
+		"import": "./lib/index.js",
+		"require": "./lib/index.js"
 	},
 	"files": [
 		"lib",
@@ -40,7 +41,6 @@
 	"license": "AGPL-3.0-only",
 	"devDependencies": {
 		"@babel/core": "^7.24.7",
-		"@babel/plugin-transform-modules-commonjs": "^7.24.7",
 		"@babel/preset-env": "^7.24.7",
 		"@babel/preset-react": "^7.24.7",
 		"@babel/preset-typescript": "^7.24.7",


### PR DESCRIPTION
Exports field is incomplete (requires field is missing) and is redundant since it matches exactly the main and module fields.
The PR removes it to make external projects use the latter fields when interpreting the preview package.

Replace babel plugin with preset-env config, as described here https://babeljs.io/docs/babel-plugin-transform-modules-commonjs

Refs: PREV-119