### PR TITLE
feat(deps)!: drop support for carbonio-design-system v8, v9, and v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
 		"react-pdf": "^10.2.0"
 	},
 	"peerDependencies": {
-		"@zextras/carbonio-design-system": "^8.0.0 || ^9.0.0-devel || ^10.0.0-devel || ^11.0.0-devel || ^12.0.0",
+		"@zextras/carbonio-design-system": "^11.0.0-devel || ^12.0.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1"
 	},


### PR DESCRIPTION
BREAKING CHANGE: peerDependency @zextras/carbonio-design-system updated from "^8.0.0 || ^9.0.0-devel || ^10.0.0-devel || ^11.0.0-devel || ^12.0.0" to "^11.0.0-devel || ^12.0.0". Projects using design system v8, v9, or v10 must upgrade before adopting this version.