### PR TITLE
chore(deps): bump vitest to 4.1.8 and @types/node to 22.19.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
 		"@types/node": "20.19.40",
 		"@types/react": "18.3.28",
 		"@types/react-dom": "18.3.7",
-		"@vitest/coverage-v8": "3.2.4",
-		"@vitest/ui": "3.2.4",
+		"@vitest/coverage-v8": "4.1.8",
+		"@vitest/ui": "4.1.8",
 		"@zextras/carbonio-ui-configs": "1.0.4",
 		"conventional-changelog-conventionalcommits": "9.3.1",
 		"eslint": "8.57.1",
@@ -71,7 +71,7 @@
 		"sonarqube-scanner": "4.3.6",
 		"ts-node": "10.9.2",
 		"typescript": "5.8.2",
-		"vitest": "3.2.4",
+		"vitest": "4.1.8",
 		"vitest-fail-on-console": "0.10.1"
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"@testing-library/jest-dom": "6.9.1",
 		"@testing-library/react": "16.3.2",
 		"@testing-library/user-event": "14.6.1",
-		"@types/node": "20.19.40",
+		"@types/node": "22.19.19",
 		"@types/react": "18.3.28",
 		"@types/react-dom": "18.3.7",
 		"@vitest/coverage-v8": "4.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
     devDependencies:
       '@commitlint/cli':
         specifier: 20.5.3
-        version: 20.5.3(@types/node@20.19.40)(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(typescript@5.8.2)
+        version: 20.5.3(@types/node@22.19.19)(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(typescript@5.8.2)
       '@commitlint/config-conventional':
         specifier: 20.5.3
         version: 20.5.3
@@ -35,10 +35,10 @@ importers:
         version: 10.4.0
       '@microsoft/api-documenter':
         specifier: 7.30.5
-        version: 7.30.5(@types/node@20.19.40)
+        version: 7.30.5(@types/node@22.19.19)
       '@microsoft/api-extractor':
         specifier: 7.57.7
-        version: 7.57.7(@types/node@20.19.40)
+        version: 7.57.7(@types/node@22.19.19)
       '@testing-library/dom':
         specifier: 10.4.1
         version: 10.4.1
@@ -52,8 +52,8 @@ importers:
         specifier: 14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
-        specifier: 20.19.40
-        version: 20.19.40
+        specifier: 22.19.19
+        version: 22.19.19
       '@types/react':
         specifier: 18.3.28
         version: 18.3.28
@@ -98,16 +98,16 @@ importers:
         version: 4.3.6
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@types/node@20.19.40)(typescript@5.8.2)
+        version: 10.9.2(@types/node@22.19.19)(typescript@5.8.2)
       typescript:
         specifier: 5.8.2
         version: 5.8.2
       vitest:
         specifier: 4.1.8
-        version: 4.1.8(@types/node@20.19.40)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0)(vite@7.3.3(@types/node@20.19.40)(jiti@2.6.1))
+        version: 4.1.8(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0)(vite@7.3.3(@types/node@22.19.19)(jiti@2.6.1))
       vitest-fail-on-console:
         specifier: 0.10.1
-        version: 0.10.1(@vitest/utils@4.1.8)(vite@7.3.3(@types/node@20.19.40)(jiti@2.6.1))(vitest@4.1.8)
+        version: 0.10.1(@vitest/utils@4.1.8)(vite@7.3.3(@types/node@22.19.19)(jiti@2.6.1))(vitest@4.1.8)
 
 packages:
 
@@ -1119,8 +1119,8 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
-  '@types/node@20.19.40':
-    resolution: {integrity: sha512-xxx6M2IpSTnnKcR0cMvIiohkiCx20/oRPtWGbenFygKCGl3zqUzdNjQ/1V4solq1LU+dgv0nQzeGOuqkqZGg0Q==}
+  '@types/node@22.19.19':
+    resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -4393,11 +4393,11 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@commitlint/cli@20.5.3(@types/node@20.19.40)(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(typescript@5.8.2)':
+  '@commitlint/cli@20.5.3(@types/node@22.19.19)(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(typescript@5.8.2)':
     dependencies:
       '@commitlint/format': 20.5.0
       '@commitlint/lint': 20.5.3
-      '@commitlint/load': 20.5.3(@types/node@20.19.40)(typescript@5.8.2)
+      '@commitlint/load': 20.5.3(@types/node@22.19.19)(typescript@5.8.2)
       '@commitlint/read': 20.5.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)
       '@commitlint/types': 20.5.0
       tinyexec: 1.2.4
@@ -4442,14 +4442,14 @@ snapshots:
       '@commitlint/rules': 20.5.3
       '@commitlint/types': 20.5.0
 
-  '@commitlint/load@20.5.3(@types/node@20.19.40)(typescript@5.8.2)':
+  '@commitlint/load@20.5.3(@types/node@22.19.19)(typescript@5.8.2)':
     dependencies:
       '@commitlint/config-validator': 20.5.0
       '@commitlint/execute-rule': 20.0.0
       '@commitlint/resolve-extends': 20.5.3
       '@commitlint/types': 20.5.0
       cosmiconfig: 9.0.1(typescript@5.8.2)
-      cosmiconfig-typescript-loader: 6.3.0(@types/node@20.19.40)(cosmiconfig@9.0.1(typescript@5.8.2))(typescript@5.8.2)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@22.19.19)(cosmiconfig@9.0.1(typescript@5.8.2))(typescript@5.8.2)
       es-toolkit: 1.47.0
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
@@ -4809,43 +4809,43 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@microsoft/api-documenter@7.30.5(@types/node@20.19.40)':
+  '@microsoft/api-documenter@7.30.5(@types/node@22.19.19)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.33.8(@types/node@20.19.40)
+      '@microsoft/api-extractor-model': 7.33.8(@types/node@22.19.19)
       '@microsoft/tsdoc': 0.16.0
-      '@rushstack/node-core-library': 5.23.1(@types/node@20.19.40)
-      '@rushstack/terminal': 0.24.0(@types/node@20.19.40)
-      '@rushstack/ts-command-line': 5.3.9(@types/node@20.19.40)
+      '@rushstack/node-core-library': 5.23.1(@types/node@22.19.19)
+      '@rushstack/terminal': 0.24.0(@types/node@22.19.19)
+      '@rushstack/ts-command-line': 5.3.9(@types/node@22.19.19)
       js-yaml: 4.1.1
       resolve: 1.22.12
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor-model@7.33.4(@types/node@20.19.40)':
+  '@microsoft/api-extractor-model@7.33.4(@types/node@22.19.19)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.20.3(@types/node@20.19.40)
+      '@rushstack/node-core-library': 5.20.3(@types/node@22.19.19)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor-model@7.33.8(@types/node@20.19.40)':
+  '@microsoft/api-extractor-model@7.33.8(@types/node@22.19.19)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.23.1(@types/node@20.19.40)
+      '@rushstack/node-core-library': 5.23.1(@types/node@22.19.19)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.57.7(@types/node@20.19.40)':
+  '@microsoft/api-extractor@7.57.7(@types/node@22.19.19)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.33.4(@types/node@20.19.40)
+      '@microsoft/api-extractor-model': 7.33.4(@types/node@22.19.19)
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.20.3(@types/node@20.19.40)
+      '@rushstack/node-core-library': 5.20.3(@types/node@22.19.19)
       '@rushstack/rig-package': 0.7.2
-      '@rushstack/terminal': 0.22.3(@types/node@20.19.40)
-      '@rushstack/ts-command-line': 5.3.3(@types/node@20.19.40)
+      '@rushstack/terminal': 0.22.3(@types/node@22.19.19)
+      '@rushstack/ts-command-line': 5.3.3(@types/node@22.19.19)
       diff: 8.0.4
       lodash: 4.17.23
       minimatch: 10.2.3
@@ -5099,7 +5099,7 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
-  '@rushstack/node-core-library@5.20.3(@types/node@20.19.40)':
+  '@rushstack/node-core-library@5.20.3(@types/node@22.19.19)':
     dependencies:
       ajv: 8.18.0
       ajv-draft-04: 1.0.0(ajv@8.18.0)
@@ -5110,9 +5110,9 @@ snapshots:
       resolve: 1.22.12
       semver: 7.5.4
     optionalDependencies:
-      '@types/node': 20.19.40
+      '@types/node': 22.19.19
 
-  '@rushstack/node-core-library@5.23.1(@types/node@20.19.40)':
+  '@rushstack/node-core-library@5.23.1(@types/node@22.19.19)':
     dependencies:
       ajv: 8.18.0
       ajv-draft-04: 1.0.0(ajv@8.18.0)
@@ -5123,45 +5123,45 @@ snapshots:
       resolve: 1.22.12
       semver: 7.7.4
     optionalDependencies:
-      '@types/node': 20.19.40
+      '@types/node': 22.19.19
 
-  '@rushstack/problem-matcher@0.2.1(@types/node@20.19.40)':
+  '@rushstack/problem-matcher@0.2.1(@types/node@22.19.19)':
     optionalDependencies:
-      '@types/node': 20.19.40
+      '@types/node': 22.19.19
 
   '@rushstack/rig-package@0.7.2':
     dependencies:
       resolve: 1.22.12
       strip-json-comments: 3.1.1
 
-  '@rushstack/terminal@0.22.3(@types/node@20.19.40)':
+  '@rushstack/terminal@0.22.3(@types/node@22.19.19)':
     dependencies:
-      '@rushstack/node-core-library': 5.20.3(@types/node@20.19.40)
-      '@rushstack/problem-matcher': 0.2.1(@types/node@20.19.40)
+      '@rushstack/node-core-library': 5.20.3(@types/node@22.19.19)
+      '@rushstack/problem-matcher': 0.2.1(@types/node@22.19.19)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 20.19.40
+      '@types/node': 22.19.19
 
-  '@rushstack/terminal@0.24.0(@types/node@20.19.40)':
+  '@rushstack/terminal@0.24.0(@types/node@22.19.19)':
     dependencies:
-      '@rushstack/node-core-library': 5.23.1(@types/node@20.19.40)
-      '@rushstack/problem-matcher': 0.2.1(@types/node@20.19.40)
+      '@rushstack/node-core-library': 5.23.1(@types/node@22.19.19)
+      '@rushstack/problem-matcher': 0.2.1(@types/node@22.19.19)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 20.19.40
+      '@types/node': 22.19.19
 
-  '@rushstack/ts-command-line@5.3.3(@types/node@20.19.40)':
+  '@rushstack/ts-command-line@5.3.3(@types/node@22.19.19)':
     dependencies:
-      '@rushstack/terminal': 0.22.3(@types/node@20.19.40)
+      '@rushstack/terminal': 0.22.3(@types/node@22.19.19)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
     transitivePeerDependencies:
       - '@types/node'
 
-  '@rushstack/ts-command-line@5.3.9(@types/node@20.19.40)':
+  '@rushstack/ts-command-line@5.3.9(@types/node@22.19.19)':
     dependencies:
-      '@rushstack/terminal': 0.24.0(@types/node@20.19.40)
+      '@rushstack/terminal': 0.24.0(@types/node@22.19.19)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -5319,7 +5319,7 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
-  '@types/node@20.19.40':
+  '@types/node@22.19.19':
     dependencies:
       undici-types: 6.21.0
 
@@ -5602,7 +5602,7 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@20.19.40)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0)(vite@7.3.3(@types/node@20.19.40)(jiti@2.6.1))
+      vitest: 4.1.8(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0)(vite@7.3.3(@types/node@22.19.19)(jiti@2.6.1))
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -5613,13 +5613,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@7.3.3(@types/node@20.19.40)(jiti@2.6.1))':
+  '@vitest/mocker@4.1.8(vite@7.3.3(@types/node@22.19.19)(jiti@2.6.1))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.3(@types/node@20.19.40)(jiti@2.6.1)
+      vite: 7.3.3(@types/node@22.19.19)(jiti@2.6.1)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -5648,7 +5648,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@20.19.40)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0)(vite@7.3.3(@types/node@20.19.40)(jiti@2.6.1))
+      vitest: 4.1.8(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0)(vite@7.3.3(@types/node@22.19.19)(jiti@2.6.1))
 
   '@vitest/utils@4.1.8':
     dependencies:
@@ -6109,9 +6109,9 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig-typescript-loader@6.3.0(@types/node@20.19.40)(cosmiconfig@9.0.1(typescript@5.8.2))(typescript@5.8.2):
+  cosmiconfig-typescript-loader@6.3.0(@types/node@22.19.19)(cosmiconfig@9.0.1(typescript@5.8.2))(typescript@5.8.2):
     dependencies:
-      '@types/node': 20.19.40
+      '@types/node': 22.19.19
       cosmiconfig: 9.0.1(typescript@5.8.2)
       jiti: 2.6.1
       typescript: 5.8.2
@@ -8397,14 +8397,14 @@ snapshots:
     dependencies:
       typescript: 5.8.2
 
-  ts-node@10.9.2(@types/node@20.19.40)(typescript@5.8.2):
+  ts-node@10.9.2(@types/node@22.19.19)(typescript@5.8.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.40
+      '@types/node': 22.19.19
       acorn: 8.16.0
       acorn-walk: 8.3.5
       arg: 4.1.3
@@ -8546,7 +8546,7 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  vite@7.3.3(@types/node@20.19.40)(jiti@2.6.1):
+  vite@7.3.3(@types/node@22.19.19)(jiti@2.6.1):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -8555,21 +8555,21 @@ snapshots:
       rollup: 4.60.4
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 20.19.40
+      '@types/node': 22.19.19
       fsevents: 2.3.3
       jiti: 2.6.1
 
-  vitest-fail-on-console@0.10.1(@vitest/utils@4.1.8)(vite@7.3.3(@types/node@20.19.40)(jiti@2.6.1))(vitest@4.1.8):
+  vitest-fail-on-console@0.10.1(@vitest/utils@4.1.8)(vite@7.3.3(@types/node@22.19.19)(jiti@2.6.1))(vitest@4.1.8):
     dependencies:
       '@vitest/utils': 4.1.8
       chalk: 5.6.2
-      vite: 7.3.3(@types/node@20.19.40)(jiti@2.6.1)
-      vitest: 4.1.8(@types/node@20.19.40)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0)(vite@7.3.3(@types/node@20.19.40)(jiti@2.6.1))
+      vite: 7.3.3(@types/node@22.19.19)(jiti@2.6.1)
+      vitest: 4.1.8(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0)(vite@7.3.3(@types/node@22.19.19)(jiti@2.6.1))
 
-  vitest@4.1.8(@types/node@20.19.40)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0)(vite@7.3.3(@types/node@20.19.40)(jiti@2.6.1)):
+  vitest@4.1.8(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0)(vite@7.3.3(@types/node@22.19.19)(jiti@2.6.1)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@7.3.3(@types/node@20.19.40)(jiti@2.6.1))
+      '@vitest/mocker': 4.1.8(vite@7.3.3(@types/node@22.19.19)(jiti@2.6.1))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -8586,10 +8586,10 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.3(@types/node@20.19.40)(jiti@2.6.1)
+      vite: 7.3.3(@types/node@22.19.19)(jiti@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 20.19.40
+      '@types/node': 22.19.19
       '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
       '@vitest/ui': 4.1.8(vitest@4.1.8)
       jsdom: 27.4.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,11 +61,11 @@ importers:
         specifier: 18.3.7
         version: 18.3.7(@types/react@18.3.28)
       '@vitest/coverage-v8':
-        specifier: 3.2.4
-        version: 3.2.4(vitest@3.2.4)
+        specifier: 4.1.8
+        version: 4.1.8(vitest@4.1.8)
       '@vitest/ui':
-        specifier: 3.2.4
-        version: 3.2.4(vitest@3.2.4)
+        specifier: 4.1.8
+        version: 4.1.8(vitest@4.1.8)
       '@zextras/carbonio-ui-configs':
         specifier: 1.0.4
         version: 1.0.4(@testing-library/dom@10.4.1)
@@ -103,11 +103,11 @@ importers:
         specifier: 5.8.2
         version: 5.8.2
       vitest:
-        specifier: 3.2.4
-        version: 3.2.4(@types/node@20.19.40)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.4.0)
+        specifier: 4.1.8
+        version: 4.1.8(@types/node@20.19.40)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0)(vite@7.3.3(@types/node@20.19.40)(jiti@2.6.1))
       vitest-fail-on-console:
         specifier: 0.10.1
-        version: 0.10.1(@vitest/utils@3.2.4)(vite@7.3.3(@types/node@20.19.40)(jiti@2.6.1))(vitest@3.2.4)
+        version: 0.10.1(@vitest/utils@4.1.8)(vite@7.3.3(@types/node@20.19.40)(jiti@2.6.1))(vitest@4.1.8)
 
 packages:
 
@@ -116,10 +116,6 @@ packages:
 
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
-
-  '@ampproject/remapping@2.3.0':
-    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
-    engines: {node: '>=6.0.0'}
 
   '@asamuzakjp/css-color@4.1.2':
     resolution: {integrity: sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==}
@@ -591,14 +587,6 @@ packages:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
 
-  '@isaacs/cliui@8.0.2':
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
-
-  '@istanbuljs/schema@0.1.6':
-    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
-    engines: {node: '>=8'}
-
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -789,10 +777,6 @@ packages:
 
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
-
-  '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
 
   '@pkgr/core@0.3.6':
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
@@ -1063,6 +1047,9 @@ packages:
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -1400,48 +1387,48 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@vitest/coverage-v8@3.2.4':
-    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
+  '@vitest/coverage-v8@4.1.8':
+    resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
     peerDependencies:
-      '@vitest/browser': 3.2.4
-      vitest: 3.2.4
+      '@vitest/browser': 4.1.8
+      vitest: 4.1.8
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@3.2.4':
-    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
 
-  '@vitest/mocker@3.2.4':
-    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.2.4':
-    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
 
-  '@vitest/runner@3.2.4':
-    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
 
-  '@vitest/snapshot@3.2.4':
-    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
 
-  '@vitest/spy@3.2.4':
-    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
 
-  '@vitest/ui@3.2.4':
-    resolution: {integrity: sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==}
+  '@vitest/ui@4.1.8':
+    resolution: {integrity: sha512-RUS2ZU2TsduVrI+9c12uTNaKrNUTsm6yFt3fueEUB9iKvyC2UP83F+sqIz00HQIah4UOL1TMoDAki8K0NjGvsA==}
     peerDependencies:
-      vitest: 3.2.4
+      vitest: 4.1.8
 
-  '@vitest/utils@3.2.4':
-    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
   '@zextras/carbonio-design-system@12.0.4':
     resolution: {integrity: sha512-fYKQGdk3X2kuT3qSZs7ACrnn4JBbapRoDy+bavi5VewiKASJHk2HVBjK2DOdfGSIWgnuxPofmsGcJ5xmvCZdkg==}
@@ -1540,10 +1527,6 @@ packages:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
-  ansi-styles@6.2.3:
-    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
-    engines: {node: '>=12'}
-
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -1612,8 +1595,8 @@ packages:
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
-  ast-v8-to-istanbul@0.3.12:
-    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
+  ast-v8-to-istanbul@1.0.3:
+    resolution: {integrity: sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -1720,10 +1703,6 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
-
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -1740,8 +1719,8 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  chai@5.3.3:
-    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
   chalk@1.1.3:
@@ -1763,10 +1742,6 @@ packages:
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
-
-  check-error@2.1.3:
-    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
-    engines: {node: '>= 16'}
 
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
@@ -1865,6 +1840,9 @@ packages:
 
   convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   core-js@3.39.0:
     resolution: {integrity: sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==}
@@ -1966,10 +1944,6 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
-  deep-eql@5.0.2:
-    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
-    engines: {node: '>=6'}
-
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -2033,9 +2007,6 @@ packages:
   duplexer2@0.1.4:
     resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
 
-  eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -2080,8 +2051,8 @@ packages:
     resolution: {integrity: sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==}
     engines: {node: '>= 0.4'}
 
-  es-module-lexer@1.7.0:
-    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
@@ -2428,10 +2399,6 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
-  foreground-child@3.3.1:
-    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
-    engines: {node: '>=14'}
-
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
@@ -2512,11 +2479,6 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
-
-  glob@10.5.0:
-    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -2856,10 +2818,6 @@ packages:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
     engines: {node: '>=10'}
 
-  istanbul-lib-source-maps@5.0.6:
-    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
-    engines: {node: '>=10'}
-
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
@@ -2867,9 +2825,6 @@ packages:
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
-
-  jackspeak@3.4.3:
-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   java-properties@1.0.2:
     resolution: {integrity: sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==}
@@ -2887,9 +2842,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-tokens@9.0.1:
-    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -3012,9 +2964,6 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  loupe@3.2.1:
-    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
-
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -3033,8 +2982,8 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  magicast@0.3.5:
-    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
 
   make-asynchronous@1.1.0:
     resolution: {integrity: sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==}
@@ -3136,16 +3085,8 @@ packages:
     resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  minimatch@9.0.9:
-    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-
-  minipass@7.1.3:
-    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
-    engines: {node: '>=16 || 14 >=14.17'}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -3310,6 +3251,10 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.2:
+    resolution: {integrity: sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==}
+    engines: {node: '>=12.20.0'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -3369,9 +3314,6 @@ packages:
     resolution: {integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==}
     engines: {node: '>=4'}
 
-  package-json-from-dist@1.0.1:
-    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
-
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -3427,20 +3369,12 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
-  path-scurry@1.11.1:
-    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
-    engines: {node: '>=16 || 14 >=14.18'}
-
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pathval@2.0.1:
-    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
-    engines: {node: '>= 14.16'}
 
   pdfjs-dist@5.4.296:
     resolution: {integrity: sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==}
@@ -3817,8 +3751,8 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -3837,10 +3771,6 @@ packages:
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
-
-  string-width@5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
 
   string.prototype.includes@2.0.1:
     resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
@@ -3876,10 +3806,6 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
-  strip-ansi@7.2.0:
-    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
-    engines: {node: '>=12'}
-
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
@@ -3903,9 +3829,6 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
-
-  strip-literal@3.1.0:
-    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   stylis@4.2.0:
     resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
@@ -3962,10 +3885,6 @@ packages:
     resolution: {integrity: sha512-d79HhZya5Djd7am0q+W4RTsSU+D/aJzM+4Y4AGJGuGlgM2L6sx5ZvOYTmZjqPhrDrV6xJTtRSm1JCLj6V6LHLQ==}
     engines: {node: '>=14.16'}
 
-  test-exclude@7.0.2:
-    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
-    engines: {node: '>=18'}
-
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
@@ -3992,9 +3911,6 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@0.3.2:
-    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
-
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
@@ -4003,16 +3919,8 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@1.1.1:
-    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-
-  tinyrainbow@2.0.0:
-    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
-    engines: {node: '>=14.0.0'}
-
-  tinyspy@4.0.4:
-    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@7.4.2:
@@ -4178,11 +4086,6 @@ packages:
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
-  vite-node@3.2.4:
-    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-
   vite@7.3.3:
     resolution: {integrity: sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4230,26 +4133,39 @@ packages:
       vite: '>=4.5.2'
       vitest: '>=0.26.2'
 
-  vitest@3.2.4:
-    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.4
-      '@vitest/ui': 3.2.4
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
-      '@types/debug':
+      '@opentelemetry/api':
         optional: true
       '@types/node':
         optional: true
-      '@vitest/browser':
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -4327,10 +4243,6 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
-  wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
-
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -4401,11 +4313,6 @@ snapshots:
   '@acemir/cssom@0.9.31': {}
 
   '@adobe/css-tools@4.5.0': {}
-
-  '@ampproject/remapping@2.3.0':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
 
   '@asamuzakjp/css-color@4.1.2':
     dependencies:
@@ -4879,17 +4786,6 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
-  '@isaacs/cliui@8.0.2':
-    dependencies:
-      string-width: 5.1.2
-      string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.2.0
-      strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: wrap-ansi@7.0.0
-
-  '@istanbuljs/schema@0.1.6': {}
-
   '@jest/schemas@29.6.3':
     dependencies:
       '@sinclair/typebox': 0.27.10
@@ -5103,9 +4999,6 @@ snapshots:
   '@octokit/types@16.0.0':
     dependencies:
       '@octokit/openapi-types': 27.0.0
-
-  '@pkgjs/parseargs@0.11.0':
-    optional: true
 
   '@pkgr/core@0.3.6': {}
 
@@ -5357,6 +5250,8 @@ snapshots:
   '@sindresorhus/is@4.6.0': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -5695,77 +5590,71 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4)':
+  '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
     dependencies:
-      '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
-      ast-v8-to-istanbul: 0.3.12
-      debug: 4.4.3
+      '@vitest/utils': 4.1.8
+      ast-v8-to-istanbul: 1.0.3
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.2.0
-      magic-string: 0.30.21
-      magicast: 0.3.5
-      std-env: 3.10.0
-      test-exclude: 7.0.2
-      tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@20.19.40)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.4.0)
-    transitivePeerDependencies:
-      - supports-color
+      magicast: 0.5.3
+      obug: 2.1.2
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@types/node@20.19.40)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0)(vite@7.3.3(@types/node@20.19.40)(jiti@2.6.1))
 
-  '@vitest/expect@3.2.4':
+  '@vitest/expect@4.1.8':
     dependencies:
+      '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      tinyrainbow: 2.0.0
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.3(@types/node@20.19.40)(jiti@2.6.1))':
+  '@vitest/mocker@4.1.8(vite@7.3.3(@types/node@20.19.40)(jiti@2.6.1))':
     dependencies:
-      '@vitest/spy': 3.2.4
+      '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.3(@types/node@20.19.40)(jiti@2.6.1)
 
-  '@vitest/pretty-format@3.2.4':
+  '@vitest/pretty-format@4.1.8':
     dependencies:
-      tinyrainbow: 2.0.0
+      tinyrainbow: 3.1.0
 
-  '@vitest/runner@3.2.4':
+  '@vitest/runner@4.1.8':
     dependencies:
-      '@vitest/utils': 3.2.4
+      '@vitest/utils': 4.1.8
       pathe: 2.0.3
-      strip-literal: 3.1.0
 
-  '@vitest/snapshot@3.2.4':
+  '@vitest/snapshot@4.1.8':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@3.2.4':
-    dependencies:
-      tinyspy: 4.0.4
+  '@vitest/spy@4.1.8': {}
 
-  '@vitest/ui@3.2.4(vitest@3.2.4)':
+  '@vitest/ui@4.1.8(vitest@4.1.8)':
     dependencies:
-      '@vitest/utils': 3.2.4
+      '@vitest/utils': 4.1.8
       fflate: 0.8.3
       flatted: 3.4.2
       pathe: 2.0.3
       sirv: 3.0.2
       tinyglobby: 0.2.17
-      tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@20.19.40)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.4.0)
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@types/node@20.19.40)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0)(vite@7.3.3(@types/node@20.19.40)(jiti@2.6.1))
 
-  '@vitest/utils@3.2.4':
+  '@vitest/utils@4.1.8':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
-      loupe: 3.2.1
-      tinyrainbow: 2.0.0
+      '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@zextras/carbonio-design-system@12.0.4(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(date-fns@3.6.0)(lodash@4.18.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -5882,8 +5771,6 @@ snapshots:
 
   ansi-styles@5.2.0: {}
 
-  ansi-styles@6.2.3: {}
-
   any-promise@1.3.0: {}
 
   arg@4.1.3: {}
@@ -5977,7 +5864,7 @@ snapshots:
 
   ast-types-flow@0.0.8: {}
 
-  ast-v8-to-istanbul@0.3.12:
+  ast-v8-to-istanbul@1.0.3:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
@@ -6072,8 +5959,6 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  cac@6.7.14: {}
-
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -6093,13 +5978,7 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  chai@5.3.3:
-    dependencies:
-      assertion-error: 2.0.1
-      check-error: 2.1.3
-      deep-eql: 5.0.2
-      loupe: 3.2.1
-      pathval: 2.0.1
+  chai@6.2.2: {}
 
   chalk@1.1.3:
     dependencies:
@@ -6123,8 +6002,6 @@ snapshots:
   chalk@5.6.2: {}
 
   char-regex@1.0.2: {}
-
-  check-error@2.1.3: {}
 
   ci-info@4.4.0: {}
 
@@ -6223,6 +6100,8 @@ snapshots:
   convert-hrtime@5.0.0: {}
 
   convert-source-map@1.9.0: {}
+
+  convert-source-map@2.0.0: {}
 
   core-js@3.39.0: {}
 
@@ -6326,8 +6205,6 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
-  deep-eql@5.0.2: {}
-
   deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
@@ -6383,8 +6260,6 @@ snapshots:
   duplexer2@0.1.4:
     dependencies:
       readable-stream: 2.3.8
-
-  eastasianwidth@0.2.0: {}
 
   emoji-regex@8.0.0: {}
 
@@ -6487,7 +6362,7 @@ snapshots:
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
 
-  es-module-lexer@1.7.0: {}
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.2:
     dependencies:
@@ -6929,11 +6804,6 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
-  foreground-child@3.3.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
-
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -7033,15 +6903,6 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
-
-  glob@10.5.0:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 3.4.3
-      minimatch: 9.0.9
-      minipass: 7.1.3
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
 
   glob@7.2.3:
     dependencies:
@@ -7364,14 +7225,6 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@5.0.6:
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3
-      istanbul-lib-coverage: 3.2.2
-    transitivePeerDependencies:
-      - supports-color
-
   istanbul-reports@3.2.0:
     dependencies:
       html-escaper: 2.0.2
@@ -7386,12 +7239,6 @@ snapshots:
       has-symbols: 1.1.0
       set-function-name: 2.0.2
 
-  jackspeak@3.4.3:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
-
   java-properties@1.0.2: {}
 
   jiti@2.6.1: {}
@@ -7401,8 +7248,6 @@ snapshots:
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
-
-  js-tokens@9.0.1: {}
 
   js-yaml@4.1.1:
     dependencies:
@@ -7535,8 +7380,6 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  loupe@3.2.1: {}
-
   lru-cache@10.4.3: {}
 
   lru-cache@11.5.1: {}
@@ -7551,7 +7394,7 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  magicast@0.3.5:
+  magicast@0.5.3:
     dependencies:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
@@ -7637,13 +7480,7 @@ snapshots:
     dependencies:
       brace-expansion: 2.1.1
 
-  minimatch@9.0.9:
-    dependencies:
-      brace-expansion: 2.1.1
-
   minimist@1.2.8: {}
-
-  minipass@7.1.3: {}
 
   mrmime@2.0.1: {}
 
@@ -7742,6 +7579,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
 
+  obug@2.1.2: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -7799,8 +7638,6 @@ snapshots:
 
   p-try@1.0.0: {}
 
-  package-json-from-dist@1.0.1: {}
-
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -7849,16 +7686,9 @@ snapshots:
 
   path-parse@1.0.7: {}
 
-  path-scurry@1.11.1:
-    dependencies:
-      lru-cache: 10.4.3
-      minipass: 7.1.3
-
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
-
-  pathval@2.0.1: {}
 
   pdfjs-dist@5.4.296:
     optionalDependencies:
@@ -8330,7 +8160,7 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  std-env@3.10.0: {}
+  std-env@4.1.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -8358,12 +8188,6 @@ snapshots:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-
-  string-width@5.1.2:
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.2.0
 
   string.prototype.includes@2.0.1:
     dependencies:
@@ -8427,10 +8251,6 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
-  strip-ansi@7.2.0:
-    dependencies:
-      ansi-regex: 6.2.2
-
   strip-bom@3.0.0: {}
 
   strip-final-newline@3.0.0: {}
@@ -8444,10 +8264,6 @@ snapshots:
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
-
-  strip-literal@3.1.0:
-    dependencies:
-      js-tokens: 9.0.1
 
   stylis@4.2.0: {}
 
@@ -8513,12 +8329,6 @@ snapshots:
       type-fest: 2.19.0
       unique-string: 3.0.0
 
-  test-exclude@7.0.2:
-    dependencies:
-      '@istanbuljs/schema': 0.1.6
-      glob: 10.5.0
-      minimatch: 10.2.5
-
   text-decoder@1.2.7:
     dependencies:
       b4a: 1.8.1
@@ -8548,8 +8358,6 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@0.3.2: {}
-
   tinyexec@1.2.4: {}
 
   tinyglobby@0.2.17:
@@ -8557,11 +8365,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
-  tinypool@1.1.1: {}
-
-  tinyrainbow@2.0.0: {}
-
-  tinyspy@4.0.4: {}
+  tinyrainbow@3.1.0: {}
 
   tldts-core@7.4.2: {}
 
@@ -8742,27 +8546,6 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  vite-node@3.2.4(@types/node@20.19.40)(jiti@2.6.1):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 7.3.3(@types/node@20.19.40)(jiti@2.6.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vite@7.3.3(@types/node@20.19.40)(jiti@2.6.1):
     dependencies:
       esbuild: 0.27.7
@@ -8776,55 +8559,42 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
 
-  vitest-fail-on-console@0.10.1(@vitest/utils@3.2.4)(vite@7.3.3(@types/node@20.19.40)(jiti@2.6.1))(vitest@3.2.4):
+  vitest-fail-on-console@0.10.1(@vitest/utils@4.1.8)(vite@7.3.3(@types/node@20.19.40)(jiti@2.6.1))(vitest@4.1.8):
     dependencies:
-      '@vitest/utils': 3.2.4
+      '@vitest/utils': 4.1.8
       chalk: 5.6.2
       vite: 7.3.3(@types/node@20.19.40)(jiti@2.6.1)
-      vitest: 3.2.4(@types/node@20.19.40)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.4.0)
+      vitest: 4.1.8(@types/node@20.19.40)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0)(vite@7.3.3(@types/node@20.19.40)(jiti@2.6.1))
 
-  vitest@3.2.4(@types/node@20.19.40)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@27.4.0):
+  vitest@4.1.8(@types/node@20.19.40)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@27.4.0)(vite@7.3.3(@types/node@20.19.40)(jiti@2.6.1)):
     dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.3(@types/node@20.19.40)(jiti@2.6.1))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@7.3.3(@types/node@20.19.40)(jiti@2.6.1))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
+      obug: 2.1.2
       pathe: 2.0.3
       picomatch: 4.0.4
-      std-env: 3.10.0
+      std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 0.3.2
+      tinyexec: 1.2.4
       tinyglobby: 0.2.17
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
+      tinyrainbow: 3.1.0
       vite: 7.3.3(@types/node@20.19.40)(jiti@2.6.1)
-      vite-node: 3.2.4(@types/node@20.19.40)(jiti@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.40
-      '@vitest/ui': 3.2.4(vitest@3.2.4)
+      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
+      '@vitest/ui': 4.1.8(vitest@4.1.8)
       jsdom: 27.4.0
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   vue-eslint-parser@9.4.3(eslint@8.57.1):
     dependencies:
@@ -8919,12 +8689,6 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-
-  wrap-ansi@8.1.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 5.1.2
-      strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
 		"noEmit": true,
 		"jsx": "react-jsx",
 		"noImplicitAny": false,
-		"types": ["vitest/globals"]
+		"types": ["vitest/globals", "node"]
 	},
 	"include": ["src"]
 }


### PR DESCRIPTION
## Summary

| Package | Bucket | Old → New | Bump | PM |
|---|---|---|---|---|
| `vitest` | devDependencies | `3.2.4` → `4.1.8` | major | pnpm |
| `@vitest/coverage-v8` | devDependencies | `3.2.4` → `4.1.8` | major (lockstep) | pnpm |
| `@vitest/ui` | devDependencies | `3.2.4` → `4.1.8` | major (lockstep) | pnpm |
| `@types/node` | devDependencies | `20.19.40` → `22.19.19` | major | pnpm |

Bump deliberato di Vitest alla nuova major **v4**. I tre pacchetti `@vitest/*` si muovono in lockstep.
`vitest-fail-on-console@0.10.1` resta invariato: il suo peer `vitest: >=0.26.2` è già soddisfatto da v4.

`@types/node` viene allineato alla **major 22**, coerente con il runtime/`engines.node: v22` del progetto (prima era fermo alla 20). Rilevante proprio dopo questo bump: vedi sotto.

## Code changes

- **`tsconfig.json`** — aggiunto `"node"` a `compilerOptions.types` (ora `["vitest/globals", "node"]`).
  Vitest 4 [non riesporta più i tipi di Node dal main entry point](https://vitest.dev/guide/migration) (*"Remove Node types from the main entry point, use `vitest/node` instead"*). Con `types` esplicito il campo restringe i type globali caricati, quindi i file di test che usano `global` (`PdfPreview.test.tsx`) e `fs`/`Buffer` (`src/tests/utils.tsx`) non risolvevano più — risolto includendo esplicitamente `@types/node` nel campo `types`.

Nessun'altra modifica al codice o alla `vitest.config.ts` è stata necessaria: il progetto non usa nessuna delle opzioni rimosse (`workspace`, `environmentMatchGlobs`, `poolMatchGlobs`, `minWorkers`, reporter `basic`, `UserConfig`), il mock di `react-pdf` è un mock manuale (`__mocks__/react-pdf.tsx`) e gli spy sui getter sono espliciti (`vi.spyOn(obj, prop, 'get')`), non automock — quindi non toccati dal rewrite dello spying.

Il salto major di `@types/node` (20 → 22) non ha introdotto errori di tipo.

## Verification

Tutti i check eseguiti su Node v22.22.0 (v4 richiede Node 20+), sia dopo il bump vitest sia dopo il bump @types/node:

- ✅ `type-check` (`tsc`) — falliva prima del fix a `tsconfig.json` (`global`/`fs`/`Buffer` non trovati), verde dopo
- ✅ `lint` (eslint)
- ✅ `test` (`vitest run`) — **8 file di test, 80 test passati**
- ✅ `build` (`build:lib` + `build:docs`)

> Nota: i file generati `docs/api/*.md` toccati dal `build:docs` (drift pre-esistente di api-documenter, non legato a questi bump) sono stati ripristinati per non sporcare il commit.

## Context7 sources

- `/vitest-dev/vitest/v4.1.6` — interrogato per *migration guide v3→v4*, breaking changes su module mocking / automock getter, reporter `verbose`, opzioni coverage e tipi Node.

## Migration guide

Riferimento ufficiale: https://vitest.dev/guide/migration · Blog: https://vitest.dev/blog/vitest-4

---

<details>
<summary>Changelog completo vitest 3.2.4 → 4.1.8 (vitest-dev/vitest)</summary>

#### [`v3.2.5`](https://github.com/vitest-dev/vitest/releases/tag/v3.2.5)

### &nbsp;&nbsp;&nbsp;🚀 Features

- **api**: Add `allowWrite` and `allowExec` options to `api` [backport to v3] &nbsp;-&nbsp; by @hi-ogawa and **Codex** in https://github.com/vitest-dev/vitest/issues/10445 [<samp>(af88b)</samp>](https://github.com/vitest-dev/vitest/commit/af88b1f5d)

### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes

- **browser**: Disable client `cdp` API when `allowWrite/allowExec: false` [backport to v3] &nbsp;-&nbsp; by @hi-ogawa and **Codex** in https://github.com/vitest-dev/vitest/issues/10456 [<samp>(385a1)</samp>](https://github.com/vitest-dev/vitest/commit/385a1aefd)

##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/vitest-dev/vitest/compare/v3.2.4...v3.2.5)

---

#### [`v3.2.6`](https://github.com/vitest-dev/vitest/releases/tag/v3.2.6)

### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes

- Pin last supported vite-node version &nbsp;-&nbsp; by @sheremet-va [<samp>(16f12)</samp>](https://github.com/vitest-dev/vitest/commit/16f120d05)

##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/vitest-dev/vitest/compare/v3.2.5...v3.2.6)

---

#### [`v4.0.0`](https://github.com/vitest-dev/vitest/releases/tag/v4.0.0)

Vitest 4.0 is out!

To stay updated, read our [blog post](https://vitest.dev/blog/vitest-4) and check the [migration guide](https://vitest.dev/guide/migration).

### &nbsp;&nbsp;&nbsp;🚨 Breaking Changes

- Remove `'basic'` reporter &nbsp;-&nbsp; by @AriPerkkio in https://github.com/vitest-dev/vitest/issues/7884 [<samp>(82fcf)</samp>](https://github.com/vitest-dev/vitest/commit/82fcf5d53)
- Simplify default exclude pattern &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/6287 [<samp>(14c50)</samp>](https://github.com/vitest-dev/vitest/commit/14c507200)
- Remove deprecated getSourceMap &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8194 [<samp>(ff934)</samp>](https://github.com/vitest-dev/vitest/commit/ff93444f8)
- Replace deprecated ErrorWithDiff with TestError &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8195 [<samp>(da59e)</samp>](https://github.com/vitest-dev/vitest/commit/da59eb887)
- Remove UserConfig type in favor of ViteUserConfig &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8196 [<samp>(22f7f)</samp>](https://github.com/vitest-dev/vitest/commit/22f7f2db5)
- Remove deprecated coverage options in favor of `vitest/node` exports &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8197 [<samp>(dc848)</samp>](https://github.com/vitest-dev/vitest/commit/dc8486d22)
- Remove deprecated internal helpers and environment exports &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8198 [<samp>(4703c)</samp>](https://github.com/vitest-dev/vitest/commit/4703cf850)
- Remove deprecated typecheck and runner types &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8199 [<samp>(89a1c)</samp>](https://github.com/vitest-dev/vitest/commit/89a1cb626)
- Remove Node types from the main entry point, use `vitest/node` instead &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8200 [<samp>(1e60c)</samp>](https://github.com/vitest-dev/vitest/commit/1e60c4f44)
- Remove support for Vite 5 &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8202 [<samp>(cb8b0)</samp>](https://github.com/vitest-dev/vitest/commit/cb8b03bac)
- Remove deprecated types &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8203 [<samp>(66bee)</samp>](https://github.com/vitest-dev/vitest/commit/66bee836f)
- Remove deprecated environmentMatchGlobs and poolMatchGlobs &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8205 [<samp>(be11d)</samp>](https://github.com/vitest-dev/vitest/commit/be11d374c)
- Remove deprecated `workspace` option in favor of `projects` &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8218 [<samp>(76fb7)</samp>](https://github.com/vitest-dev/vitest/commit/76fb75d42)
- Ignore `--standalone` when CLI filename filter is used &nbsp;-&nbsp; by @AriPerkkio in https://github.com/vitest-dev/vitest/issues/8262 [<samp>(013bf)</samp>](https://github.com/vitest-dev/vitest/commit/013bf2cb2)
- Use module-runner instead of vite-node &nbsp;-&nbsp; by @sheremet-va and @AriPerkkio in https://github.com/vitest-dev/vitest/issues/8208 [<samp>(9be01)</samp>](https://github.com/vitest-dev/vitest/commit/9be01ba59)
- Rewrite spying implementation to make module mocking more intuitive &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8363 [<samp>(9e412)</samp>](https://github.com/vitest-dev/vitest/commit/9e412de35)
- Remove deprecated APIs &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8428 [<samp>(a1cb9)</samp>](https://github.com/vitest-dev/vitest/commit/a1cb9719a)
- Remove `minWorkers` and set it automatically to 0 in non watch mode &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8454 [<samp>(2c2d1)</samp>](https://github.com/vitest-dev/vitest/commit/2c2d1d4ce)
- Verbose reporter prints tests in a list, introduce `tree` reporter &nbsp;-&nbsp; by @sheremet-va and @AriPerkkio in https://github.com/vitest-dev/vitest/issues/8500 [<samp>(25fd3)</samp>](https://github.com/vitest-dev/vitest/commit/25fd32bf0)
- Include shadow root contents in pretty-format output &nbsp;-&nbsp; by @wkillerud in https://github.com/vitest-dev/vitest/issues/8545 [<samp>(9e722)</samp>](https://github.com/vitest-dev/vitest/commit/9e722834a)
- Remove deprecated order from test() API &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8594 [<samp>(4d419)</samp>](https://github.com/vitest-dev/vitest/commit/4d41928c6)
- Rewrite pools without `tinypool` &nbsp;-&nbsp; by @AriPerkkio and @sheremet-va in https://github.com/vitest-dev/vitest/issues/8705 [<samp>(4822d)</samp>](https://github.com/vitest-dev/vitest/commit/4822d047a)
- **browser**: Require a provider factory instead of a string &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8445 [<samp>(606cb)</samp>](https://github.com/vitest-dev/vitest/commit/606cb9e3e)
- **expect**: Pass current equality testers to asymmetric matcher &nbsp;-&nbsp; by @hi-ogawa in https://github.com/vitest-dev/vitest/issues/6825 [<samp>(965ce)</samp>](https://github.com/vitest-dev/vitest/commit/965cefc19)
- **projects**: Allow only files that have "vitest.config" or "vite.config" in the name &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8542 [<samp>(304bc)</samp>](https://github.com/vitest-dev/vitest/commit/304bc20f0)
- **reporter**: Remove deprecated APIs &nbsp;-&nbsp; by @AriPerkkio and @sheremet-va in https://github.com/vitest-dev/vitest/issues/8223 [<samp>(149f8)</samp>](https://github.com/vitest-dev/vitest/commit/149f8e509)
- **runner**: Set mode to `todo` if no function is passed down to `test` or `describe` &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8346 [<samp>(1a81c)</samp>](https://github.com/vitest-dev/vitest/commit/1a81c21d2)
- **snapshot**: Fail test with obsolete snapshot on CI &nbsp;-&nbsp; by @hi-ogawa in https://github.com/vitest-dev/vitest/issues/7963 [<samp>(4d84f)</samp>](https://github.com/vitest-dev/vitest/commit/4d84f0ac6)
- **spy**: Support spying on classes &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/6160 [<samp>(abc0d)</samp>](https://github.com/vitest-dev/vitest/commit/abc0d8273)

### &nbsp;&nbsp;&nbsp;🚀 Features

- Provide entity to onConsoleLog &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8159 [<samp>(437d4)</samp>](https://github.com/vitest-dev/vitest/commit/437d461aa)
- Add `onUnhandledError` callback &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8162 [<samp>(924cb)</samp>](https://github.com/vitest-dev/vitest/commit/924cb6961)
- Add spy option to vi.mockObject &nbsp;-&nbsp; by @rChaoz in https://github.com/vitest-dev/vitest/issues/8285 [<samp>(81d76)</samp>](https://github.com/vitest-dev/vitest/commit/81d7601e4)
- Don't use vite-node in coverage packages &nbsp;-&nbsp; by @sheremet-va [<samp>(ffdb4)</samp>](https://github.com/vitest-dev/vitest/commit/ffdb4d5fd)
- Clickable dashboard numbers &nbsp;-&nbsp; by @shairez in https://github.com/vitest-dev/vitest/issues/7406 [<samp>(2344c)</samp>](https://github.com/vitest-dev/vitest/commit/2344c1f6e)
- Display test "path" when filtering &nbsp;-&nbsp; by @userquin in https://github.com/vitest-dev/vitest/issues/8547 [<samp>(2e491)</samp>](https://github.com/vitest-dev/vitest/commit/2e4918954)
- Introduce separate packages for browser mode providers &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8629 [<samp>(0dc93)</samp>](https://github.com/vitest-dev/vitest/commit/0dc93ea98)
- Add hooks with type-safe extra context to TestAPI &nbsp;-&nbsp; by @ysfaran in https://github.com/vitest-dev/vitest/issues/8623 [<samp>(6b21c)</samp>](https://github.com/vitest-dev/vitest/commit/6b21cfe55)
- Support `expect.assert` for type narrowing &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8695 [<samp>(fe589)</samp>](https://github.com/vitest-dev/vitest/commit/fe5895d2b)
- Add `displayAnnotations` option to `github-options` &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8706 [<samp>(4a66d)</samp>](https://github.com/vitest-dev/vitest/commit/4a66df625)
- Add schema validation matchers &nbsp;-&nbsp; by @zirkelc in https://github.com/vitest-dev/vitest/issues/8527 [<samp>(c0b25)</samp>](https://github.com/vitest-dev/vitest/commit/c0b250e5c)
- Add a way to dump transformed content &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8711 [<samp>(931c0)</samp>](https://github.com/vitest-dev/vitest/commit/931c0ee63)
- **api**:
  - Expose `experimental_parseSpecifications` &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8408 [<samp>(fdeb2)</samp>](https://github.com/vitest-dev/vitest/commit/fdeb2f482)
  - Expose Vitest watcher &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8413 [<samp>(aaa6e)</samp>](https://github.com/vitest-dev/vitest/commit/aaa6e6512)
  - Add `enableCoverage` and `disableCoverage` methods &nbsp;-&nbsp; by @sheremet-va and @AriPerkkio in https://github.com/vitest-dev/vitest/issues/8412 [<samp>(61eb7)</samp>](https://github.com/vitest-dev/vitest/commit/61eb7dd9c)
  - Add `getGlobalTestNamePattern` method &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8438 [<samp>(bdb70)</samp>](https://github.com/vitest-dev/vitest/commit/bdb7067f1)
  - Add `relativeModuleId` to `TestModule` &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8505 [<samp>(3be09)</samp>](https://github.com/vitest-dev/vitest/commit/3be0986aa)
  - Add `getSeed` method &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8592 [<samp>(438c4)</samp>](https://github.com/vitest-dev/vitest/commit/438c44e7f)
- **browser**:
  - Support `toBeInViewport` utility method to assert element is in viewport or not &nbsp;-&nbsp; by @Shinyaigeek in https://github.com/vitest-dev/vitest/issues/8234 [<samp>(ceed5)</samp>](https://github.com/vitest-dev/vitest/commit/ceed5b622)
  - Add qwik to the `vitest init` cli command &nbsp;-&nbsp; by @thejackshelton in https://github.com/vitest-dev/vitest/issues/8330 [<samp>(1638b)</samp>](https://github.com/vitest-dev/vitest/commit/1638b44e8)
  - Introduce `toMatchScreenshot` for Visual Regression Testing &nbsp;-&nbsp; by @macarie in https://github.com/vitest-dev/vitest/issues/8041 [<samp>(d45f9)</samp>](https://github.com/vitest-dev/vitest/commit/d45f964c1)
  - Add `trackUnhandledErrors` option &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8386 [<samp>(c0ec0)</samp>](https://github.com/vitest-dev/vitest/commit/c0ec08a90)
  - Support iframe locator with playwright provider &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8016 [<samp>(57b2c)</samp>](https://github.com/vitest-dev/vitest/commit/57b2cca2e)
  - Add `length` property to locators, `toHaveLength` now accepts locators &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8512 [<samp>(2308c)</samp>](https://github.com/vitest-dev/vitest/commit/2308cbf13)
  - Support playwright tracing &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8584 [<samp>(1aac5)</samp>](https://github.com/vitest-dev/vitest/commit/1aac59cd2)
  - Expose `options` on `BrowserProviderOption` &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8609 [<samp>(0d0e5)</samp>](https://github.com/vitest-dev/vitest/commit/0d0e5cdf6)
  - Support `--inspect` option in webdriverio &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8613 [<samp>(38adc)</samp>](https://github.com/vitest-dev/vitest/commit/38adc86cf)
  - Support custom screenshot comparison algorithms &nbsp;-&nbsp; by @macarie in https://github.com/vitest-dev/vitest/issues/8687 [<samp>(e63b1)</samp>](https://github.com/vitest-dev/vitest/commit/e63b17efc)
- **coverage**:
  - `autoUpdate` to support percentage formatting &nbsp;-&nbsp; by @Battjmo and @AriPerkkio in https://github.com/vitest-dev/vitest/issues/8456 [<samp>(99e01)</samp>](https://github.com/vitest-dev/vitest/commit/99e016bec)
- **expect**:
  - Support `toBeNullable` expect function to check provided value is nullish &nbsp;-&nbsp; by @Shinyaigeek and @sheremet-va in https://github.com/vitest-dev/vitest/issues/8294 [<samp>(eeec5)</samp>](https://github.com/vitest-dev/vitest/commit/eeec501de)
- **mocker**:
  - Add `automocker` entry &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8301 [<samp>(e9c92)</samp>](https://github.com/vitest-dev/vitest/commit/e9c928252)

### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes

- Allow overriding globals in types &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8215 [<samp>(2248b)</samp>](https://github.com/vitest-dev/vitest/commit/2248b06d4)
- Remove unused dependencies &nbsp;-&nbsp; by @AriPerkkio in https://github.com/vitest-dev/vitest/issues/8184 [<samp>(feadc)</samp>](https://github.com/vitest-dev/vitest/commit/feadc60af)
- Distribute test files to shards more evenly &nbsp;-&nbsp; by @Shinyaigeek and @AriPerkkio in https://github.com/vitest-dev/vitest/issues/8288 [<samp>(7b489)</samp>](https://github.com/vitest-dev/vitest/commit/7b489959a)
- Use suite's timeout when `test.extend` &nbsp;-&nbsp; by @AriPerkkio in https://github.com/vitest-dev/vitest/issues/8278 [<samp>(43977)</samp>](https://github.com/vitest-dev/vitest/commit/43977c2b8)
- Support snapshot with no object key sorting &nbsp;-&nbsp; by @hi-ogawa and @sheremet-va in https://github.com/vitest-dev/vitest/issues/8136 [<samp>(e85e3)</samp>](https://github.com/vitest-dev/vitest/commit/e85e396f0)
- Annotation location always points to the test file &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8315 [<samp>(88071)</samp>](https://github.com/vitest-dev/vitest/commit/88071a8f2)
- Add `--changed` flag support to `vitest list` command &nbsp;-&nbsp; by @haakonjackfloat in https://github.com/vitest-dev/vitest/issues/8270 and https://github.com/vitest-dev/vitest/issues/8272 [<samp>(e71a5)</samp>](https://github.com/vitest-dev/vitest/commit/e71a5d0ec)
- Prevent rpc timeout on slow thread blocking synchronous methods &nbsp;-&nbsp; by @AriPerkkio and @sheremet-va in https://github.com/vitest-dev/vitest/issues/8297 [<samp>(bea87)</samp>](https://github.com/vitest-dev/vitest/commit/bea874610)
- Forbid setting environment to `browser` &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8334 [<samp>(0417a)</samp>](https://github.com/vitest-dev/vitest/commit/0417a2c1a)
- Invalidate modules in all module graphs when the file is changed &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8352 [<samp>(94ab3)</samp>](https://github.com/vitest-dev/vitest/commit/94ab392b3)
- Screenshot masks with Playwright provider &nbsp;-&nbsp; by @macarie in https://github.com/vitest-dev/vitest/issues/8357 [<samp>(459ef)</samp>](https://github.com/vitest-dev/vitest/commit/459efba6b)
- Configure `oxc` instead of `esbuild` on `rolldown-vite` &nbsp;-&nbsp; by @hi-ogawa in https://github.com/vitest-dev/vitest/issues/8378 [<samp>(e922e)</samp>](https://github.com/vitest-dev/vitest/commit/e922e9266)
- Make sure test errors always have `stacks` property in Node.js context &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8392 [<samp>(b825e)</samp>](https://github.com/vitest-dev/vitest/commit/b825ef87c)
- Support `import.meta.resolve` on Vite 7 &nbsp;-&nbsp; by @hi-ogawa in https://github.com/vitest-dev/vitest/issues/8493 [<samp>(549d3)</samp>](https://github.com/vitest-dev/vitest/commit/549d321e2)
- Show the assertion error first when `expect.poll` assertion fails &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8483 [<samp>(fb450)</samp>](https://github.com/vitest-dev/vitest/commit/fb4500bec)
- Override fake timers when `useFakeTimers` is called multiple times &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8504 [<samp>(ed7e3)</samp>](https://github.com/vitest-dev/vitest/commit/ed7e3ad5d)
- Custom expect messages for `expect.extend` matchers &nbsp;-&nbsp; by @lzl0304 in https://github.com/vitest-dev/vitest/issues/8520 [<samp>(96945)</samp>](https://github.com/vitest-dev/vitest/commit/969456b4a)
- Process sourcemaps for stack traces from `globalSetup` files &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8534 [<samp>(8978a)</samp>](https://github.com/vitest-dev/vitest/commit/8978a23b7)
- Resolve performance issue when throwing errors with stackTraceLimit = 0 &nbsp;-&nbsp; by @Copilot, **sheremet-va** and @AriPerkkio in https://github.com/vitest-dev/vitest/issues/8531 [<samp>(6d5b5)</samp>](https://github.com/vitest-dev/vitest/commit/6d5b5b1a5)
- Avoid recursively applying `$` and `%` formatting to `test.for/each` title &nbsp;-&nbsp; by @hi-ogawa in https://github.com/vitest-dev/vitest/issues/8557 [<samp>(ea6d7)</samp>](https://github.com/vitest-dev/vitest/commit/ea6d7322e)
- Replace wildcard exports `"./*"` with specific files in vitest package &nbsp;-&nbsp; by @hi-ogawa in https://github.com/vitest-dev/vitest/issues/8560 [<samp>(ce746)</samp>](https://github.com/vitest-dev/vitest/commit/ce7466408)
- Don't publish unused d.ts files &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8562 [<samp>(42dfd)</samp>](https://github.com/vitest-dev/vitest/commit/42dfd1c43)
- Remove loupe dependencies from `optimizeDeps.include` for browser mode &nbsp;-&nbsp; by @jake-danton in https://github.com/vitest-dev/vitest/issues/8570 [<samp>(cdcf7)</samp>](https://github.com/vitest-dev/vitest/commit/cdcf7e854)
- Update `engines` field to drop Node 18 support &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8608 [<samp>(9a0bf)</samp>](https://github.com/vitest-dev/vitest/commit/9a0bf2254)
- Correctly inherit test options on extended tests &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8618 [<samp>(15c09)</samp>](https://github.com/vitest-dev/vitest/commit/15c091a99)
- Update @types/node peer deps &nbsp;-&nbsp; by @sheremet-va [<samp>(ee6b2)</samp>](https://github.com/vitest-dev/vitest/commit/ee6b27b5f)
- Re-export CDP Session directly from playwright &nbsp;-&nbsp; by @mrginglymus in https://github.com/vitest-dev/vitest/issues/8702 [<samp>(9553a)</samp>](https://github.com/vitest-dev/vitest/commit/9553ab923)
- Disable trackUnhandledErrors if inspector is enabled &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8732 [<samp>(acac7)</samp>](https://github.com/vitest-dev/vitest/commit/acac7104d)
- `base` option doesn't crash vitest &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8760 [<samp>(9f0ec)</samp>](https://github.com/vitest-dev/vitest/commit/9f0ecccb8)
  - Run in-source tests only when the file itsels is a test file &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8204 [<samp>(bdd2e)</samp>](https://github.com/vitest-dev/vitest/commit/bdd2e01c3)
  - `locator.element()` returns `HTMLElement` or `SVGElement` &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8440 [<samp>(c1ac1)</samp>](https://github.com/vitest-dev/vitest/commit/c1ac15c6b)
  - Don't import from `vite` directly &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8541 [<samp>(d7fca)</samp>](https://github.com/vitest-dev/vitest/commit/d7fca0389)
  - Update expect.element type to match the implementation &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8597 [<samp>(b2804)</samp>](https://github.com/vitest-dev/vitest/commit/b2804a1f9)
  - Throw an error if iframe is not accessible anymore &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8601 [<samp>(6acdc)</samp>](https://github.com/vitest-dev/vitest/commit/6acdc3a5e)
  - Stop creating unnecessary directories when taking screenshots &nbsp;-&nbsp; by @macarie in https://github.com/vitest-dev/vitest/issues/8605 [<samp>(b1c8f)</samp>](https://github.com/vitest-dev/vitest/commit/b1c8fdbe9)
  - Always define commands &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8626 [<samp>(acbe0)</samp>](https://github.com/vitest-dev/vitest/commit/acbe0e973)
  - Exclude deprecated context import from optimization &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8658 [<samp>(a96ea)</samp>](https://github.com/vitest-dev/vitest/commit/a96ea140e)
  - Allow importing BrowserCommand if no browser package is installed &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8666 [<samp>(95c36)</samp>](https://github.com/vitest-dev/vitest/commit/95c367f5e)
  - Define an export for browser/utils &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8678 [<samp>(529ab)</samp>](https://github.com/vitest-dev/vitest/commit/529ab46ac)
  - Allow service workers to mock the network in chromium without breaking vi.mock &nbsp;-&nbsp; by @Georgegriff and @sheremet-va in https://github.com/vitest-dev/vitest/issues/8668 [<samp>(87108)</samp>](https://github.com/vitest-dev/vitest/commit/87108db33)
  - Support sync `not.toBeInTheDocument()` &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8751 [<samp>(f5d06)</samp>](https://github.com/vitest-dev/vitest/commit/f5d06434f)
- **core**:
  - Fix `objectContaining` expect utility to have more compatibility to jest's one &nbsp;-&nbsp; by @Shinyaigeek in https://github.com/vitest-dev/vitest/issues/8241 [<samp>(480be)</samp>](https://github.com/vitest-dev/vitest/commit/480be1a78)
  - Include files based on `--project` filter &nbsp;-&nbsp; by @gtbuchanan in https://github.com/vitest-dev/vitest/issues/7885 [<samp>(761be)</samp>](https://github.com/vitest-dev/vitest/commit/761beeeea)
  - Prevent encoding filenames of uncovered files &nbsp;-&nbsp; by @AriPerkkio in https://github.com/vitest-dev/vitest/issues/8239 [<samp>(8a998)</samp>](https://github.com/vitest-dev/vitest/commit/8a9988043)
  - Handle query param based transforms correctly &nbsp;-&nbsp; by @AriPerkkio in https://github.com/vitest-dev/vitest/issues/8418 [<samp>(a400a)</samp>](https://github.com/vitest-dev/vitest/commit/a400a9d2a)
  - Enforce order of `vitest:coverage-transform` plugin &nbsp;-&nbsp; by @AriPerkkio in https://github.com/vitest-dev/vitest/issues/8477 [<samp>(ff517)</samp>](https://github.com/vitest-dev/vitest/commit/ff5170cff)
  - V8 to ignore Vite's generated cjs import helpers &nbsp;-&nbsp; by @mrginglymus and @AriPerkkio in https://github.com/vitest-dev/vitest/issues/8718 [<samp>(35816)</samp>](https://github.com/vitest-dev/vitest/commit/35816fe8d)
  - Keep only strings in `coverage.exclude` &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8731 [<samp>(c9c30)</samp>](https://github.com/vitest-dev/vitest/commit/c9c303178)
- **deps**:
  - Update all non-major dependencies &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8235 [<samp>(a1e57)</samp>](https://github.com/vitest-dev/vitest/commit/a1e576ae0)
  - Update all non-major dependencies &nbsp;-&nbsp; in https://github.com/vitest-dev/vitest/issues/8328 [<samp>(aa79e)</samp>](https://github.com/vitest-dev/vitest/commit/aa79e2733)
  - Update all non-major dependencies &nbsp;-&nbsp; in https://github.com/vitest-dev/vitest/issues/8348 [<samp>(13f94)</samp>](https://github.com/vitest-dev/vitest/commit/13f946229)
  - Update all non-major dependencies &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8382 [<samp>(704eb)</samp>](https://github.com/vitest-dev/vitest/commit/704eba24b)
  - Update all non-major dependencies &nbsp;-&nbsp; in https://github.com/vitest-dev/vitest/issues/8550 [<samp>(048f7)</samp>](https://github.com/vitest-dev/vitest/commit/048f7a1ca)
- **jsdom**:
  - Override globals that Fetch API relies on &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8390 [<samp>(05b41)</samp>](https://github.com/vitest-dev/vitest/commit/05b4178e8)
  - Support AbortSignal API &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8704 [<samp>(f6690)</samp>](https://github.com/vitest-dev/vitest/commit/f6690ed46)
  - Fix `regexpHoistable` to allow whitespace before parentheses &nbsp;-&nbsp; by @cszhjh in https://github.com/vitest-dev/vitest/issues/8231 [<samp>(a0f9a)</samp>](https://github.com/vitest-dev/vitest/commit/a0f9ae3f0)
- **module-runner**:
  - Resolve `resolvedSources` correctly &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8736 [<samp>(8fc52)</samp>](https://github.com/vitest-dev/vitest/commit/8fc52974f)
  - Support getBuiltins &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8746 [<samp>(87bb8)</samp>](https://github.com/vitest-dev/vitest/commit/87bb8f49c)
- **pool**:
  - Properly reuse the vm pool &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8758 [<samp>(08498)</samp>](https://github.com/vitest-dev/vitest/commit/08498f0e9)
- **reporter**:
  - Invisible CLI menus when `vitest --standalone` &nbsp;-&nbsp; by @AriPerkkio in https://github.com/vitest-dev/vitest/issues/8248 [<samp>(37cc2)</samp>](https://github.com/vitest-dev/vitest/commit/37cc26994)
- **rolldown-vite**:
  - Properly disable minifier in the browser client &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8306 [<samp>(f55bb)</samp>](https://github.com/vitest-dev/vitest/commit/f55bb81e6)
- **runner**:
  - Don't bundle runner with utils &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8496 [<samp>(2b4b0)</samp>](https://github.com/vitest-dev/vitest/commit/2b4b05823)
- **spy**:
  - Fix spyOn types with optional method &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8499 [<samp>(d3afa)</samp>](https://github.com/vitest-dev/vitest/commit/d3afa601a)
  - Can respy on an exported method &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8521 [<samp>(bf450)</samp>](https://github.com/vitest-dev/vitest/commit/bf450b433)
  - Don't fail when spying on static getters &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8589 [<samp>(ac1d9)</samp>](https://github.com/vitest-dev/vitest/commit/ac1d92f14)
- **types**:
  - Ensure Chai declaration merge works with TS-Go &nbsp;-&nbsp; by @LukeAbby in https://github.com/vitest-dev/vitest/issues/8188 [<samp>(5261d)</samp>](https://github.com/vitest-dev/vitest/commit/5261df0b9)
  - Allow returning a promise from defineConfig &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8651 [<samp>(c3474)</samp>](https://github.com/vitest-dev/vitest/commit/c347487e6)
- **ui**:
  - Keep the same tab open when clicking on different tests &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8599 [<samp>(3e535)</samp>](https://github.com/vitest-dev/vitest/commit/3e535f78b)
- **utils**:
  - Remove ast export &nbsp;-&nbsp; by @bluwy in https://github.com/vitest-dev/vitest/issues/8435 [<samp>(21622)</samp>](https://github.com/vitest-dev/vitest/commit/21622b5ae)
- **vitest**:
  - Override `config.include` option with `config.browser.instances[].include` option if it is specified &nbsp;-&nbsp; by @Shinyaigeek in https://github.com/vitest-dev/vitest/issues/8260 [<samp>(010fc)</samp>](https://github.com/vitest-dev/vitest/commit/010fc55b5)
- **watch**:
  - Filename filter runs duplicate tests in workspaces &nbsp;-&nbsp; by @AriPerkkio in https://github.com/vitest-dev/vitest/issues/8250 [<samp>(932d8)</samp>](https://github.com/vitest-dev/vitest/commit/932d837c6)
- **wdio**:
  - Wait for the driver to be properly closed &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8305 [<samp>(c16ab)</samp>](https://github.com/vitest-dev/vitest/commit/c16abe71e)
  - Properly construct the shadow root selector if there are multiple elements &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8354 [<samp>(28765)</samp>](https://github.com/vitest-dev/vitest/commit/28765b4bb)

### &nbsp;&nbsp;&nbsp;🏎 Performance

- Avoid spawning extra workers if no tests will run there &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8446 [<samp>(3fb3e)</samp>](https://github.com/vitest-dev/vitest/commit/3fb3e8036)
- Don't set `process.title` &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8453 [<samp>(0a766)</samp>](https://github.com/vitest-dev/vitest/commit/0a7666323)
- Remove chai as a direct dependency, keep it in `@vitest/expect` &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8461 [<samp>(cc98c)</samp>](https://github.com/vitest-dev/vitest/commit/cc98c611f)
- Reduce the amount of dynamic imports &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8465 [<samp>(db6cd)</samp>](https://github.com/vitest-dev/vitest/commit/db6cd73ba)
- Use ES2022 language features &nbsp;-&nbsp; by @TrevorBurnham in https://github.com/vitest-dev/vitest/issues/8492 [<samp>(bb34c)</samp>](https://github.com/vitest-dev/vitest/commit/bb34c64dc)
- Delay populating node-globals &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8506 [<samp>(41cbc)</samp>](https://github.com/vitest-dev/vitest/commit/41cbc5328)
- Get `workerId` from a global object &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8507 [<samp>(46b13)</samp>](https://github.com/vitest-dev/vitest/commit/46b13f669)
- Replace startsWith with strict equality &nbsp;-&nbsp; by @btea in https://github.com/vitest-dev/vitest/issues/8546 [<samp>(c42e6)</samp>](https://github.com/vitest-dev/vitest/commit/c42e64e62)
- Reduce the number of unused imports &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8508 [<samp>(9a79b)</samp>](https://github.com/vitest-dev/vitest/commit/9a79b90c9)
- Use experimental `meta.resolve` flag instead of a custom loader &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8567 [<samp>(2e063)</samp>](https://github.com/vitest-dev/vitest/commit/2e0630b76)
- Create only one fetcher per project &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8762 [<samp>(8e15b)</samp>](https://github.com/vitest-dev/vitest/commit/8e15bc8f9)
- **pool**: Resolve all environments first &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8759 [<samp>(d3ef4)</samp>](https://github.com/vitest-dev/vitest/commit/d3ef4f29c)

##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/vitest-dev/vitest/compare/v3.2.4...v4.0.0)

---

#### [`v4.0.0-beta.19`](https://github.com/vitest-dev/vitest/releases/tag/v4.0.0-beta.19)

### &nbsp;&nbsp;&nbsp;🚨 Breaking Changes

- Rewrite pools without `tinypool` &nbsp;-&nbsp; by @AriPerkkio and @sheremet-va in https://github.com/vitest-dev/vitest/issues/8705 [<samp>(4822d)</samp>](https://github.com/vitest-dev/vitest/commit/4822d047a)

### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes

- Disable trackUnhandledErrors if inspector is enabled &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8732 [<samp>(acac7)</samp>](https://github.com/vitest-dev/vitest/commit/acac7104d)
- **browser**:
  - Allow service workers to mock the network in chromium without breaking vi.mock &nbsp;-&nbsp; by @Georgegriff and @sheremet-va in https://github.com/vitest-dev/vitest/issues/8668 [<samp>(87108)</samp>](https://github.com/vitest-dev/vitest/commit/87108db33)
  - Support sync `not.toBeInTheDocument()` &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8751 [<samp>(f5d06)</samp>](https://github.com/vitest-dev/vitest/commit/f5d06434f)
- **coverage**:
  - V8 to ignore Vite's generated cjs import helpers &nbsp;-&nbsp; by @mrginglymus and @AriPerkkio in https://github.com/vitest-dev/vitest/issues/8718 [<samp>(35816)</samp>](https://github.com/vitest-dev/vitest/commit/35816fe8d)
  - Keep only strings in `coverage.exclude` &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8731 [<samp>(c9c30)</samp>](https://github.com/vitest-dev/vitest/commit/c9c303178)
- **module-runner**:
  - Resolve `resolvedSources` correctly &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8736 [<samp>(8fc52)</samp>](https://github.com/vitest-dev/vitest/commit/8fc52974f)
  - Support getBuiltins &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8746 [<samp>(87bb8)</samp>](https://github.com/vitest-dev/vitest/commit/87bb8f49c)

##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/vitest-dev/vitest/compare/v4.0.0-beta.18...v4.0.0-beta.19)

---

#### [`v4.0.0-beta.18`](https://github.com/vitest-dev/vitest/releases/tag/v4.0.0-beta.18)

### &nbsp;&nbsp;&nbsp;🚀 Features

- Support `expect.assert` for type narrowing &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8695 [<samp>(fe589)</samp>](https://github.com/vitest-dev/vitest/commit/fe5895d2b)
- Add `displayAnnotations` option to `github-options` &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8706 [<samp>(4a66d)</samp>](https://github.com/vitest-dev/vitest/commit/4a66df625)
- Add schema validation matchers &nbsp;-&nbsp; by @zirkelc in https://github.com/vitest-dev/vitest/issues/8527 [<samp>(c0b25)</samp>](https://github.com/vitest-dev/vitest/commit/c0b250e5c)
- Add a way to dump transformed content &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8711 [<samp>(931c0)</samp>](https://github.com/vitest-dev/vitest/commit/931c0ee63)
- **browser**: Support custom screenshot comparison algorithms &nbsp;-&nbsp; by @macarie in https://github.com/vitest-dev/vitest/issues/8687 [<samp>(e63b1)</samp>](https://github.com/vitest-dev/vitest/commit/e63b17efc)

### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes

- Re-export CDP Session directly from playwright &nbsp;-&nbsp; by @mrginglymus in https://github.com/vitest-dev/vitest/issues/8702 [<samp>(9553a)</samp>](https://github.com/vitest-dev/vitest/commit/9553ab923)
- **browser**: Define an export for browser/utils &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8678 [<samp>(529ab)</samp>](https://github.com/vitest-dev/vitest/commit/529ab46ac)
- **jsdom**: Support AbortSignal API &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8704 [<samp>(f6690)</samp>](https://github.com/vitest-dev/vitest/commit/f6690ed46)

##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/vitest-dev/vitest/compare/v4.0.0-beta.17...v4.0.0-beta.18)

---

#### [`v4.0.0-beta.17`](https://github.com/vitest-dev/vitest/releases/tag/v4.0.0-beta.17)

### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes

- **browser**: Allow importing BrowserCommand if no browser package is installed &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8666 [<samp>(95c36)</samp>](https://github.com/vitest-dev/vitest/commit/95c367f5e)

##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/vitest-dev/vitest/compare/v4.0.0-beta.16...v4.0.0-beta.17)

---

#### [`v4.0.0-beta.16`](https://github.com/vitest-dev/vitest/releases/tag/v4.0.0-beta.16)

### &nbsp;&nbsp;&nbsp;🚀 Features

- Add hooks with type-safe extra context to TestAPI &nbsp;-&nbsp; by @ysfaran in https://github.com/vitest-dev/vitest/issues/8623 [<samp>(6b21c)</samp>](https://github.com/vitest-dev/vitest/commit/6b21cfe55)

### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes

- Update @types/node peer deps &nbsp;-&nbsp; by @sheremet-va [<samp>(ee6b2)</samp>](https://github.com/vitest-dev/vitest/commit/ee6b27b5f)
- **browser**: Exclude deprecated context import from optimization &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8658 [<samp>(a96ea)</samp>](https://github.com/vitest-dev/vitest/commit/a96ea140e)
- **types**: Allow returning a promise from defineConfig &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8651 [<samp>(c3474)</samp>](https://github.com/vitest-dev/vitest/commit/c347487e6)

##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/vitest-dev/vitest/compare/v4.0.0-beta.15...v4.0.0-beta.16)

---

#### [`v4.0.0-beta.15`](https://github.com/vitest-dev/vitest/releases/tag/v4.0.0-beta.15)

*No significant changes*

##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/vitest-dev/vitest/compare/v4.0.0-beta.14...v4.0.0-beta.15)

---

#### [`v4.0.0-beta.14`](https://github.com/vitest-dev/vitest/releases/tag/v4.0.0-beta.14)

### &nbsp;&nbsp;&nbsp;🚨 Breaking Changes

- Introduce separate packages for browser mode providers &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8629 [<samp>(0dc93)</samp>](https://github.com/vitest-dev/vitest/commit/0dc93ea98)

### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes

- Correctly inherit test options on extended tests &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8618 [<samp>(15c09)</samp>](https://github.com/vitest-dev/vitest/commit/15c091a99)
- **browser**: Always define commands &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8626 [<samp>(acbe0)</samp>](https://github.com/vitest-dev/vitest/commit/acbe0e973)

##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/vitest-dev/vitest/compare/v4.0.0-beta.13...v4.0.0-beta.14)

---

#### [`v4.0.0-beta.13`](https://github.com/vitest-dev/vitest/releases/tag/v4.0.0-beta.13)

### &nbsp;&nbsp;&nbsp;🚀 Features

- **browser**:
  - Expose `options` on `BrowserProviderOption` &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8609 [<samp>(0d0e5)</samp>](https://github.com/vitest-dev/vitest/commit/0d0e5cdf6)
  - Support `--inspect` option in webdriverio &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8613 [<samp>(38adc)</samp>](https://github.com/vitest-dev/vitest/commit/38adc86cf)

### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes

- **browser**: Stop creating unnecessary directories when taking screenshots &nbsp;-&nbsp; by @macarie in https://github.com/vitest-dev/vitest/issues/8605 [<samp>(b1c8f)</samp>](https://github.com/vitest-dev/vitest/commit/b1c8fdbe9)

##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/vitest-dev/vitest/compare/v4.0.0-beta.12...v4.0.0-beta.13)

---

#### [`v4.0.0-beta.12`](https://github.com/vitest-dev/vitest/releases/tag/v4.0.0-beta.12)

### &nbsp;&nbsp;&nbsp;🚨 Breaking Changes

- Remove deprecated order from test() API &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8594 [<samp>(4d419)</samp>](https://github.com/vitest-dev/vitest/commit/4d41928c6)

### &nbsp;&nbsp;&nbsp;🚀 Features

- **api**: Add `getSeed` method &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8592 [<samp>(438c4)</samp>](https://github.com/vitest-dev/vitest/commit/438c44e7f)
- **browser**: Support playwright tracing &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8584 [<samp>(1aac5)</samp>](https://github.com/vitest-dev/vitest/commit/1aac59cd2)

### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes

- Remove loupe dependencies from `optimizeDeps.include` for browser mode &nbsp;-&nbsp; by @jake-danton in https://github.com/vitest-dev/vitest/issues/8570 [<samp>(cdcf7)</samp>](https://github.com/vitest-dev/vitest/commit/cdcf7e854)
- Update `engines` field to drop Node 18 support &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8608 [<samp>(9a0bf)</samp>](https://github.com/vitest-dev/vitest/commit/9a0bf2254)
- **browser**:
  - Update expect.element type to match the implementation &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8597 [<samp>(b2804)</samp>](https://github.com/vitest-dev/vitest/commit/b2804a1f9)
  - Throw an error if iframe is not accessible anymore &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8601 [<samp>(6acdc)</samp>](https://github.com/vitest-dev/vitest/commit/6acdc3a5e)
- **spy**:
  - Don't fail when spying on static getters &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8589 [<samp>(ac1d9)</samp>](https://github.com/vitest-dev/vitest/commit/ac1d92f14)
- **ui**:
  - Keep the same tab open when clicking on different tests &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8599 [<samp>(3e535)</samp>](https://github.com/vitest-dev/vitest/commit/3e535f78b)

### &nbsp;&nbsp;&nbsp;🏎 Performance

- Use experimental `meta.resolve` flag instead of a custom loader &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8567 [<samp>(2e063)</samp>](https://github.com/vitest-dev/vitest/commit/2e0630b76)

##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/vitest-dev/vitest/compare/v4.0.0-beta.11...v4.0.0-beta.12)

---

#### [`v4.0.0-beta.11`](https://github.com/vitest-dev/vitest/releases/tag/v4.0.0-beta.11)

### &nbsp;&nbsp;&nbsp;🚨 Breaking Changes

- Verbose reporter prints tests in a list, introduce `tree` reporter &nbsp;-&nbsp; by @sheremet-va and @AriPerkkio in https://github.com/vitest-dev/vitest/issues/8500 [<samp>(25fd3)</samp>](https://github.com/vitest-dev/vitest/commit/25fd32bf0)
- Include shadow root contents in pretty-format output &nbsp;-&nbsp; by @wkillerud in https://github.com/vitest-dev/vitest/issues/8545 [<samp>(9e722)</samp>](https://github.com/vitest-dev/vitest/commit/9e722834a)
- **expect**: Pass current equality testers to asymmetric matcher &nbsp;-&nbsp; by @hi-ogawa in https://github.com/vitest-dev/vitest/issues/6825 [<samp>(965ce)</samp>](https://github.com/vitest-dev/vitest/commit/965cefc19)
- **projects**: Allow only files that have "vitest.config" or "vite.config" in the name &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8542 [<samp>(304bc)</samp>](https://github.com/vitest-dev/vitest/commit/304bc20f0)

### &nbsp;&nbsp;&nbsp;🚀 Features

- Clickable dashboard numbers &nbsp;-&nbsp; by @shairez in https://github.com/vitest-dev/vitest/issues/7406 [<samp>(2344c)</samp>](https://github.com/vitest-dev/vitest/commit/2344c1f6e)
- Display test "path" when filtering &nbsp;-&nbsp; by @userquin in https://github.com/vitest-dev/vitest/issues/8547 [<samp>(2e491)</samp>](https://github.com/vitest-dev/vitest/commit/2e4918954)

### &nbsp;&nbsp;&nbsp;🐞 Bug Fixes

- Custom expect messages for `expect.extend` matchers &nbsp;-&nbsp; by @lzl0304 in https://github.com/vitest-dev/vitest/issues/8520 [<samp>(96945)</samp>](https://github.com/vitest-dev/vitest/commit/969456b4a)
- Process sourcemaps for stack traces from `globalSetup` files &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8534 [<samp>(8978a)</samp>](https://github.com/vitest-dev/vitest/commit/8978a23b7)
- Resolve performance issue when throwing errors with stackTraceLimit = 0 &nbsp;-&nbsp; by @Copilot, **sheremet-va** and @AriPerkkio in https://github.com/vitest-dev/vitest/issues/8531 [<samp>(6d5b5)</samp>](https://github.com/vitest-dev/vitest/commit/6d5b5b1a5)
- Avoid recursively applying `$` and `%` formatting to `test.for/each` title &nbsp;-&nbsp; by @hi-ogawa in https://github.com/vitest-dev/vitest/issues/8557 [<samp>(ea6d7)</samp>](https://github.com/vitest-dev/vitest/commit/ea6d7322e)
- Replace wildcard exports `"./*"` with specific files in vitest package &nbsp;-&nbsp; by @hi-ogawa in https://github.com/vitest-dev/vitest/issues/8560 [<samp>(ce746)</samp>](https://github.com/vitest-dev/vitest/commit/ce7466408)
- Don't publish unused d.ts files &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8562 [<samp>(42dfd)</samp>](https://github.com/vitest-dev/vitest/commit/42dfd1c43)
- **browser**: Don't import from `vite` directly &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8541 [<samp>(d7fca)</samp>](https://github.com/vitest-dev/vitest/commit/d7fca0389)
- **deps**: Update all non-major dependencies &nbsp;-&nbsp; in https://github.com/vitest-dev/vitest/issues/8550 [<samp>(048f7)</samp>](https://github.com/vitest-dev/vitest/commit/048f7a1ca)
- **spy**: Can respy on an exported method &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8521 [<samp>(bf450)</samp>](https://github.com/vitest-dev/vitest/commit/bf450b433)

### &nbsp;&nbsp;&nbsp;🏎 Performance

- Replace startsWith with strict equality &nbsp;-&nbsp; by @btea in https://github.com/vitest-dev/vitest/issues/8546 [<samp>(c42e6)</samp>](https://github.com/vitest-dev/vitest/commit/c42e64e62)
- Reduce the number of unused imports &nbsp;-&nbsp; by @sheremet-va in https://github.com/vitest-dev/vitest/issues/8508 [<samp>(9a79b)</samp>](https://github.com/vitest-dev/vitest/commit/9a79b90c9)

##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](https://github.com/vitest-dev/vitest/compare/v4.0.0-beta.10...v4.0.0-beta.11)

> …and 43 more release(s) omitted to respect PR body size limits. See the full [releases page](https://github.com/vitest-dev/vitest/releases).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
